### PR TITLE
Enhance dashboard with live service status

### DIFF
--- a/Orchestrator.WebApi/Class.cs
+++ b/Orchestrator.WebApi/Class.cs
@@ -49,7 +49,9 @@ namespace Orchestrator.WebApi
                         //swallow for now
                         break;
                    case "servicestatus":
-                        //swallow for now
+                        var status = env.Payload.Deserialize<ServiceStatus>();
+                        if (status != null)
+                            _envelopes.Push("ServiceStatus", status);
                         break;
                     case "consolelogmessage":
                         //Convert to ConsoleLogMessage

--- a/Orchestrator.WebUI/Components/Pages/Index.razor
+++ b/Orchestrator.WebUI/Components/Pages/Index.razor
@@ -28,6 +28,14 @@
     }
 </div>
 
+@if (services != null)
+{
+    <div class="mb-3">
+        <span><strong>@RunningServiceCount</strong> / <strong>@TotalServiceCount</strong> services running</span>
+        <span class="ms-3"><strong>@TotalRunningInstances</strong> total instances</span>
+    </div>
+}
+
 @if (services is null)
 {
     <p><em>Loading…</em></p>
@@ -137,6 +145,10 @@ else
     private List<(DateTime Timestamp, string Message)> logEntries = new();
     private List<(DateTime Timestamp, string Message)> logSupervisor = new();
 
+    private int TotalServiceCount => services?.Count ?? 0;
+    private int RunningServiceCount => services?.Count(s => s.State == State.Running) ?? 0;
+    private int TotalRunningInstances => services?.Sum(s => s.RunningInstances) ?? 0;
+
     private DotNetObjectReference<Index>? statusRef;
     private DotNetObjectReference<Index>? logRef;
     private DotNetObjectReference<Index>? supervisorLogsRef;
@@ -156,6 +168,7 @@ protected override async Task OnAfterRenderAsync(bool firstRender)
     protected override async Task OnInitializedAsync()
     {
         await Refresh();
+        await ConnectStatus();
     }
 
     private async Task ConnectStatus()
@@ -164,7 +177,7 @@ protected override async Task OnAfterRenderAsync(bool firstRender)
         statusRef = DotNetObjectReference.Create(this);
 
         var apiBase = OrchestratorConfig.Current.Web.ApiBaseUrl.TrimEnd('/');
-        var statusUrl = $"{apiBase}/api/status/stream";
+        var statusUrl = $"{apiBase}/api/services/stream";
 
         await JS.InvokeVoidAsync("logStream.status.open", statusRef, statusUrl);
         statusConnected = true;


### PR DESCRIPTION
## Summary
- stream `ServiceStatus` envelopes from the API
- forward `ServiceStatus` from the TCP client
- connect dashboard to `/api/services/stream` on init

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684214dee83c832a9dac1669ad2859c1