### PR TITLE
Fix status connection URL

### DIFF
--- a/Orchestrator.Core/Extensions/EnvelopeStreamServiceExtensions.cs
+++ b/Orchestrator.Core/Extensions/EnvelopeStreamServiceExtensions.cs
@@ -1,0 +1,33 @@
+using Orchestrator.Core.Interfaces;
+using Orchestrator.Core.Models;
+using System.Collections.Generic;
+using System.Text.Json;
+
+namespace Orchestrator.Core.Extensions
+{
+    /// <summary>Helpers for working with <see cref="IEnvelopeStreamService"/>.</summary>
+    public static class EnvelopeStreamServiceExtensions
+    {
+        /// <summary>Unwrap the envelope, yielding the strongly-typed payload.</summary>
+        public static async IAsyncEnumerable<T> StreamAsync<T>(
+            this IEnvelopeStreamService svc,
+            string topic)
+        {
+            await foreach (var envelope in svc.StreamAsync(topic))
+            {
+                yield return envelope.Payload.Deserialize<T>()!;
+            }
+        }
+
+        /// <summary>Gives you the raw JSON string of the envelope payload.</summary>
+        public static async IAsyncEnumerable<string> StreamRawAsync(
+            this IEnvelopeStreamService svc,
+            string topic)
+        {
+            await foreach (var envelope in svc.StreamAsync(topic))
+            {
+                yield return envelope.Payload.GetRawText();
+            }
+        }
+    }
+}

--- a/Orchestrator.Core/Interfaces/IEnvelopeStreamService.cs
+++ b/Orchestrator.Core/Interfaces/IEnvelopeStreamService.cs
@@ -12,28 +12,4 @@ namespace Orchestrator.Core.Interfaces
         IAsyncEnumerable<Envelope> StreamAsync(string topic);
     }
 
-    public static class EnvelopeStreamServiceExtensions
-    {
-        /// <summary>“Unwrap” the envelope, yielding the strongly-typed payload.</summary>
-        public static async IAsyncEnumerable<T> StreamAsync<T>(
-            this IEnvelopeStreamService svc,
-            string topic)
-        {
-            await foreach (var envelope in svc.StreamAsync(topic))
-            {
-                yield return envelope.Payload.Deserialize<T>()!;
-            }
-        }
-
-        /// <summary>Gives you the raw JSON string of the envelope payload.</summary>
-        public static async IAsyncEnumerable<string> StreamRawAsync(
-            this IEnvelopeStreamService svc,
-            string topic)
-        {
-            await foreach (var envelope in svc.StreamAsync(topic))
-            {
-                yield return envelope.Payload.GetRawText();
-            }
-        }
-    }
 }

--- a/Orchestrator.WebApi/Program.cs
+++ b/Orchestrator.WebApi/Program.cs
@@ -7,6 +7,7 @@ using Microsoft.OpenApi.Models;
 using Orchestrator.IPC;
 using Orchestrator.Core.Interfaces;
 using Orchestrator.Core.Models;
+using Orchestrator.Core.Extensions;
 using Orchestrator.Supervisor;
 using Microsoft.Extensions.Options;
 using System.Text.Json;
@@ -105,9 +106,8 @@ namespace Orchestrator.WebApi
                 var stream = ctx.RequestServices.GetRequiredService<IEnvelopeStreamService>();
                 ctx.Response.Headers.Add("Content-Type", "text/event-stream");
 
-                await foreach (var env in stream.StreamAsync("ServiceStatus"))
+                await foreach (var status in stream.StreamAsync<ServiceStatus>("ServiceStatus"))
                 {
-                    var status = JsonSerializer.Deserialize<ServiceStatus>(env.Payload.GetRawText())!;
                     var json = JsonSerializer.Serialize(status);
                     await ctx.Response.WriteAsync($"data: {json}\n\n");
                     await ctx.Response.Body.FlushAsync();
@@ -119,10 +119,8 @@ namespace Orchestrator.WebApi
                 var logs = ctx.RequestServices.GetRequiredService<IEnvelopeStreamService>();
                 ctx.Response.Headers.Add("Content-Type", "text/event-stream");
 
-                await foreach (var env in logs.StreamAsync("HostHeartBeat"))
+                await foreach (var status in logs.StreamAsync<InternalStatus>("HostHeartBeat"))
                 {
-                    // You can emit the full envelope, or just the payload:
-                    var status = JsonSerializer.Deserialize<InternalStatus>(env.Payload.GetRawText())!;
                     var json = JsonSerializer.Serialize(status);
                     await ctx.Response.WriteAsync($"data: {json}\n\n");
                     await ctx.Response.Body.FlushAsync();

--- a/Orchestrator.WebUI/Components/Pages/Index.razor
+++ b/Orchestrator.WebUI/Components/Pages/Index.razor
@@ -161,14 +161,13 @@ protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         _interactive = true;
         await StartSupervisorLogs();
+        await ConnectStatus();
     }
-
-    }
+}
 
     protected override async Task OnInitializedAsync()
     {
         await Refresh();
-        await ConnectStatus();
     }
 
     private async Task ConnectStatus()
@@ -176,8 +175,10 @@ protected override async Task OnAfterRenderAsync(bool firstRender)
         statusRef?.Dispose();
         statusRef = DotNetObjectReference.Create(this);
 
-        var apiBase = OrchestratorConfig.Current.Web.ApiBaseUrl.TrimEnd('/');
-        var statusUrl = $"{apiBase}/api/services/stream";
+        var baseUri = new Uri(Nav.BaseUri);
+        var apiPort = OrchestratorConfig.Current.Web.ApiPort;
+        var apiOrigin = new UriBuilder(baseUri.Scheme, baseUri.Host, apiPort).Uri;
+        var statusUrl = new Uri(apiOrigin, "/api/services/stream").ToString();
 
         await JS.InvokeVoidAsync("logStream.status.open", statusRef, statusUrl);
         statusConnected = true;

--- a/Orchestrator/EnvelopeForwarder.cs
+++ b/Orchestrator/EnvelopeForwarder.cs
@@ -4,6 +4,7 @@ using Orchestrator.Core.Interfaces;
 using Orchestrator.Core.Models;
 using Orchestrator.IPC;
 using System.Text.Json;
+using Orchestrator.Core.Extensions;
 
 namespace Orchestrator
 {

--- a/Orchestrator/Worker.cs
+++ b/Orchestrator/Worker.cs
@@ -2,6 +2,7 @@
 using Orchestrator.Core.Models;
 using Orchestrator.IPC;
 using System.Text.Json;
+using Orchestrator.Core.Extensions;
 
 public class Worker : BackgroundService
 {


### PR DESCRIPTION
## Summary
- fix the base URL used for the status event stream
- delay ConnectStatus until the first OnAfterRender to avoid prerendering JS errors
- stream typed events for status endpoints
- move envelope stream extensions into separate file

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build --verbosity normal`


------
https://chatgpt.com/codex/tasks/task_b_68422008b62c832a9df84864613cb735