### PR TITLE
Fix SSE host heartbeat forwarding

### DIFF
--- a/Orchestrator.WebApi/Class.cs
+++ b/Orchestrator.WebApi/Class.cs
@@ -41,7 +41,18 @@ namespace Orchestrator.WebApi
             switch (env.Topic.ToLowerInvariant())
             {
                 case "hostheartbeat":
-                    // swallow for now
+                    var hb = env.Payload.Deserialize<WorkerStatus>();
+                    if (hb != null)
+                    {
+                        var internalStatus = new InternalStatus
+                        {
+                            Name = hb.ServiceName,
+                            IsHealthy = hb.Healthy,
+                            Details = hb.Message,
+                            Timestamp = hb.Timestamp.UtcDateTime
+                        };
+                        _envelopes.Push("HostHeartBeat", internalStatus);
+                    }
                     break;
                 case "servicestatus":
                     var status = env.Payload.Deserialize<ServiceStatus>();


### PR DESCRIPTION
## Summary
- forward HostHeartBeat payloads to the envelope stream so `/api/status/stream` gets updates

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684247cf085c832ab4e7c3305742a942