### PR TITLE
Improve logging for JSON deserialization errors

### DIFF
--- a/Orchestrator.Core/Extensions/EnvelopeStreamServiceExtensions.cs
+++ b/Orchestrator.Core/Extensions/EnvelopeStreamServiceExtensions.cs
@@ -2,6 +2,7 @@ using Orchestrator.Core.Interfaces;
 using Orchestrator.Core.Models;
 using System.Collections.Generic;
 using System.Text.Json;
+using Microsoft.Extensions.Logging;
 
 namespace Orchestrator.Core.Extensions
 {
@@ -14,7 +15,8 @@ namespace Orchestrator.Core.Extensions
         /// </summary>
         public static async IAsyncEnumerable<T> StreamAsync<T>(
             this IEnvelopeStreamService svc,
-            string topic)
+            string topic,
+            ILogger? logger = null)
         {
             string expectedType = typeof(T).FullName!;
 
@@ -37,8 +39,11 @@ namespace Orchestrator.Core.Extensions
                 {
                     result = envelope.Payload.Deserialize<T>();
                 }
-                catch (JsonException)
+                catch (JsonException ex)
                 {
+                    logger?.LogWarning(ex,
+                        "Failed to deserialize {Type} from topic {Topic}. Payload: {Payload}",
+                        expectedType, topic, envelope.Payload.GetRawText());
                     continue; // Skip invalid payloads
                 }
 

--- a/Orchestrator.WebApi/Program.cs
+++ b/Orchestrator.WebApi/Program.cs
@@ -106,9 +106,11 @@ namespace Orchestrator.WebApi
             app.MapGet("/api/services/stream", async ctx =>
             {
                 var stream = ctx.RequestServices.GetRequiredService<IEnvelopeStreamService>();
+                var logger = ctx.RequestServices.GetRequiredService<ILoggerFactory>()
+                                 .CreateLogger("ServiceStatusStream");
                 ctx.Response.Headers.Add("Content-Type", "text/event-stream");
 
-                await foreach (var status in stream.StreamAsync<ServiceStatus>("ServiceStatus"))
+                await foreach (var status in stream.StreamAsync<ServiceStatus>("ServiceStatus", logger))
                 {
                     var json = JsonSerializer.Serialize(status);
                     await ctx.Response.WriteAsync($"data: {json}\n\n");
@@ -119,9 +121,11 @@ namespace Orchestrator.WebApi
             app.MapGet("/api/status/stream", async ctx =>
             {
                 var logs = ctx.RequestServices.GetRequiredService<IEnvelopeStreamService>();
+                var logger = ctx.RequestServices.GetRequiredService<ILoggerFactory>()
+                                 .CreateLogger("InternalStatusStream");
                 ctx.Response.Headers.Add("Content-Type", "text/event-stream");
 
-                await foreach (var status in logs.StreamAsync<InternalStatus>("HostHeartBeat"))
+                await foreach (var status in logs.StreamAsync<InternalStatus>("HostHeartBeat", logger))
                 {
                     var json = JsonSerializer.Serialize(status);
                     await ctx.Response.WriteAsync($"data: {json}\n\n");


### PR DESCRIPTION
## Summary
- add optional logger to `StreamAsync<T>`
- log JSON parse failures instead of silently skipping
- pass loggers to SSE endpoints so bad messages show up in logs

## Testing
- `dotnet build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_68424a7d4894832ab774ae962006d80b